### PR TITLE
[FIX] ES exporter secretName 'error wrong number of args for values: want 1 got 0'

### DIFF
--- a/charts/elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/elasticsearch-exporter/templates/deployment.yaml
@@ -55,14 +55,14 @@ spec:
               value: {{ .Values.url.http }}://$(ELASTIC_USER):$(ELASTICSEARCH_ADMIN_PASSWORD)@{{ .Values.url.name }}:{{ .Values.url.port }}
             - name: ELASTIC_USER
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: username
-                  name: {{ values.secretName }}
+                  name: {{ .Values.secretName }}
             - name: ELASTICSEARCH_ADMIN_PASSWORD
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: password
-                  name: {{ values.secretName }}
+                  name: {{ .Values.secretName }}
           {{ end }}
           lifecycle:
             preStop:
@@ -107,5 +107,5 @@ spec:
       - name: elasticsearch-tls-certs
         secret:
           defaultMode: 256
-          secretName: {{ values.secretName }}
+          secretName: {{ .Values.secretName }}
       {{ end }}


### PR DESCRIPTION
While deploying the exporter following the instructions from "Monitoring Integrations" UI, the deploy of the exporter via helm fails with the following error:
```
helm install -n sysdig -f values.yaml --repo https://sysdiglabs.github.io/integrations-charts sysdig-sysdigcloud-elasticsearch elasticsearch-exporter
Error: INSTALLATION FAILED: template: elasticsearch-exporter/templates/deployment.yaml:60:27: executing "elasticsearch-exporter/templates/deployment.yaml" at <values>: wrong number of args for values: want 1 got 0
```

I have modified the deployment template of ES and now the deployment is successful (tested on helm v3.8.0)