### PR TITLE
issue#24 fix volume mount key for elasticsearch-tls-cert

### DIFF
--- a/charts/elasticsearch-exporter/templates/deployment.yaml
+++ b/charts/elasticsearch-exporter/templates/deployment.yaml
@@ -98,5 +98,5 @@ spec:
       - name: elasticsearch-tls-certs
         secret:
           defaultMode: 256
-          secretTLS: {{ .Values.secretTLS }}
+          secretName: {{ .Values.secretTLS }}
       {{ end }}


### PR DESCRIPTION
this will fix the wrong key name being used for mounting tls certs from the secret