### PR TITLE
repair variable name in php-fpm-exporter template

### DIFF
--- a/charts/php-fpm-exporter/templates/patch-template.yaml
+++ b/charts/php-fpm-exporter/templates/patch-template.yaml
@@ -3,9 +3,9 @@ spec:
     metadata:
       annotations:
       {{- if .Values.sysdig.integrationType }}
-      {{- include "php-fp-exporter.sysdigAnnotations" . | nindent 8 }}
+      {{- include "php-fpm-exporter.sysdigAnnotations" . | nindent 8 }}
       {{ else }}
-      {{- include "php-fp-exporter.prometheusAnnotations" . | nindent 8 }}
+      {{- include "php-fpm-exporter.prometheusAnnotations" . | nindent 8 }}
       {{- end }}
     spec:
       containers:


### PR DESCRIPTION
A recent update ( during #54 ) managed to introduce a small but breaking typo in the php-fpm-exporter chart:

`Error: template: php-fpm-exporter/templates/patch-template.yaml:8:10: executing "php-fpm-exporter/templates/patch-template.yaml" at <include "php-fp-exporter.prometheusAnnotations" .>: error calling include: template: no template "php-fp-exporter.prometheusAnnotations" associated with template "gotpl"`

I think this should fix it.