### PR TITLE
UPDATE ksm-cadvisor to exclude unneeded dependencies

### DIFF
--- a/charts/ksm-cadvisor/Chart.yaml
+++ b/charts/ksm-cadvisor/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/ksm-cadvisor/values.yaml
+++ b/charts/ksm-cadvisor/values.yaml
@@ -5,9 +5,9 @@ prometheus:
     alertmanager.yml: ""
   kubeStateMetrics:
     enabled: true
-  nodeExporter:
+  prometheus-node-exporter:
     enabled: false
-  pushgateway:
+  prometheus-pushgateway:
     enabled: false
   server:
     persistentVolume:


### PR DESCRIPTION
When #64 bumped our the version of the `prometheus` chart, it inadvertently caused previously excluded components like `node-exporter` and `pushgateway` to be included again. Now that those components are [included as subcharts](https://github.com/prometheus-community/helm-charts/blob/prometheus-25.22.0/charts/prometheus/Chart.yaml#L36-L43), we must update our valuesfile to match the new syntax to exclude them.

Behavior in 0.0.6:
```
❯ helm template test ksm-cadvisor --repo=https://sysdiglabs.github.io/integrations-charts --version 0.0.6 | grep "image:"
        image: "k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.3.0"
          image: "jimmidyson/configmap-reload:v0.5.0"
          image: "quay.io/prometheus/prometheus:v2.34.0"
```

Behavior introduced in 0.0.7:
```
❯ helm template test ksm-cadvisor --repo=https://sysdiglabs.github.io/integrations-charts --version 0.0.7 | grep "image:"
          image: quay.io/prometheus/node-exporter:v1.6.0
        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2
          image: "quay.io/prometheus/pushgateway:v1.6.0"
          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.67.0"
          image: "quay.io/prometheus/prometheus:v2.46.0"
```

Behavior with this PR:
```
❯ helm template test ./charts/ksm-cadvisor | grep "image:"
        image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.9.2
          image: "quay.io/prometheus-operator/prometheus-config-reloader:v0.67.0"
          image: "quay.io/prometheus/prometheus:v2.46.0"
```